### PR TITLE
check-if-error-on-no-network-policy

### DIFF
--- a/resources/workload/deployment/deployment.yaml
+++ b/resources/workload/deployment/deployment.yaml
@@ -99,10 +99,6 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
           timeoutSeconds: 5
-        networkPolicy:
-          ports:
-          - port: 8080
-            protocol: TCP
         resources:
           limits:
             # CPU limits should be set


### PR DESCRIPTION
Not sure where this recommendation even came from; NetworkPolicies are a separate resource and not part of the pod definition.