### PR TITLE
Update limit-range.yaml

### DIFF
--- a/resources/namespace/limit-range.yaml
+++ b/resources/namespace/limit-range.yaml
@@ -18,4 +18,4 @@ spec:
     # maxLimitRequestRatio:
     #   memory: "1"
     #   cpu: "1"
-    # type: Container
+    type: Container

--- a/resources/namespace/limit-range.yaml
+++ b/resources/namespace/limit-range.yaml
@@ -15,7 +15,7 @@ spec:
     # The maximum amount of CPU and memory burst that a container can
     # make as a ratio of its limit over request.
     # This helps enforce the limit and request to be the same.
-    maxLimitRequestRatio:
-      memory: "1"
-      cpu: "1"
-    type: Container
+    # maxLimitRequestRatio:
+    #   memory: "1"
+    #   cpu: "1"
+    # type: Container


### PR DESCRIPTION
This pull request includes a small change to the `resources/namespace/limit-range.yaml` file. The change comments out the `maxLimitRequestRatio` configuration and the associated `type` field, which previously enforced a 1:1 ratio for CPU and memory limits over requests.Remove the MaxLimit Request ratio